### PR TITLE
Allow user to set the item's initial `isExpanded` value

### DIFF
--- a/src/kjvelarde-multiselect-searchtree-0.8.5.js
+++ b/src/kjvelarde-multiselect-searchtree-0.8.5.js
@@ -311,7 +311,12 @@
   mainModule.controller('treeItemCtrl', [
     '$scope',
     function ($scope) {
-      $scope.item.isExpanded = true;
+    
+      // Item is expanded by default
+      if ($scope.item.isExpanded !== false && $scope.item.isExpanded !== true) {
+        $scope.item.isExpanded = true;
+      }
+
       /**
      * Shows the expand option.
      *


### PR DESCRIPTION
This allows users to choose if they want the tree nodes to be expanded initially.

The default was not changed; Tree nodes will be expanded by default.

Example:

``` javascript
[1,2,3,4].map(function(i) {
  return {
    id: "node-" + i,
    name: "Node " + i,
    isExpanded: false,
    children: []
  };
});
```
